### PR TITLE
add react-webpack-starter

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -122,6 +122,7 @@
 
 ## <a name="R"> </a>R
 * [Rationale](https://github.com/KingsMentor/Rationale) - Android permission rationale helper dialog. **By [@Kingsmentor](https://twitter.com/kingsmentor)**
+* [react-webpack-starter](https://github.com/temilaj/react-webpack-starter) - A boiler plate for creating react applications bundled by webpack (using ES6, Babel, SASS and the webpack development server). **By [@temilaj](https://twitter.com/temilaj)** 
 * [Reuq](https://github.com/ifedapoolarewaju/reuq) - Frontend Javascript framework. **By @ifedapoolarewaju**
 * [River](https://github.com/abiosoft/river) - Lightweight REST framework for Go. **By [@abiosoft](https://twitter.com/abiosoft)**
 


### PR DESCRIPTION
add react-webpack-starter: A boiler plate for creating react applications bundled by webpack (using ES6, Babel, SASS and webpack development server)