### PR TITLE
add react-raise to made-in-nigeria

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -141,6 +141,7 @@
 
 ## <a name="R"> </a>R
 * [Rationale](https://github.com/KingsMentor/Rationale) - Android permission rationale helper dialog. **By [@Kingsmentor](https://twitter.com/kingsmentor)**
+* [React-Raise](https://github.com/andela-iamao/react-raise) - A cli kit for creating react applications. **By [@ash__amao](https://twitter.com/ash__amao)**
 * [react-webpack-starter](https://github.com/temilaj/react-webpack-starter) - A boiler plate for creating react applications bundled by webpack (using ES6, Babel, SASS and the webpack development server). **By [@temilaj](https://twitter.com/temilaj)**
 * [Reuq](https://github.com/ifedapoolarewaju/reuq) - Frontend Javascript framework. **By @ifedapoolarewaju**
 * [River](https://github.com/abiosoft/river) - Lightweight REST framework for Go. **By [@abiosoft](https://twitter.com/abiosoft)**


### PR DESCRIPTION
## What Does this PR do?
Add `React-Raise` created by Inumidun Amao to the made in Nigeria list. It is a CLI kit for creating react apps, it has some extended functionalities different from that of Facebook's `create-react-app`