### PR TITLE
Add TwittaSave app

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -184,6 +184,7 @@
 * [TinyPress](https://github.com/kehers/tinypress) - Create and easily manage your blog on Github. **By [@kehers](https://twitter.com/kehers)**
 * [Toast.js](https://github.com/ireade/Toast.js) - A library for Toast messages  **By [@ireaderinokun](https://twitter.com/ireaderinokun)**
 * [TweetThreader](https://github.com/Udokah/tweet-threader) - A tool to create threads on Twitter  **By [@thisisudo](https://twitter.com/thisisudo)**
+* [TwittaSave](https://github.com/emmanuelkehinde/TwittaSave-Web) - Web, Android and Chrome Extension that enables you to download videos and gifs from tweets to your device easily; built using Twitter API.  **By [@emmakoko96](https://twitter.com/emmakoko96)**
 * [TigerJS JavaScript Library](https://github.com/solutionstack/tigerjs) - A general purpose javascript framework provideing numerous modules and abstractions including for XHR , DOM, Widgets, Date, String methods and much more to enhance Javascript application development   **By [@solutionstack](https://github.com/solutionstack)
 
 ## <a name="U"> </a>U


### PR DESCRIPTION
TwittaSave - Web, Android and Chrome Extension that enables users to download videos and gifs from tweets to their device easily.