### PR TITLE
Fix simple grid bug Issue:#304

### DIFF
--- a/app/components/ProjectCard.js
+++ b/app/components/ProjectCard.js
@@ -87,14 +87,7 @@ function ProjectCard(props) {
   };
 
   return (
-    <Box
-      borderColor="gray.100"
-      borderWidth="2px"
-      borderRadius="2xl"
-      w={{ sm: "21rem", lg: "25.7rem" }}
-      maxWidth="80vw"
-      m={{ sm: 2, lg: 5 }}
-    >
+    <Box borderColor="gray.100" borderWidth="2px" borderRadius="2xl">
       <Flex alignItems="center" mx={4} my={3}>
         <Text fontWeight="bold">
           <Link

--- a/app/components/pages/ProjectsPage.js
+++ b/app/components/pages/ProjectsPage.js
@@ -195,11 +195,11 @@ const ProjectsPage = (props) => {
 
       <SimpleGrid
         columns={{ sm: 1, md: 2, lg: 3 }}
-        spacingX={{ sm: "0rem", md: "4rem" }}
-        mt="1rem"
+        spacingX={{ sm: "0rem", md: "2rem" }}
+        mt="5rem"
         mb="5rem"
-        spacingY={{ base: "2rem", lg: "0rem", md: "0" }}
-        marginLeft="-1.2em"
+        spacingY={{ base: "2rem", md: "2rem" }}
+        w="100%"
       >
         {data.slice(0, initialProjects).map((project, index) => (
           <ProjectCard key={index} project={project} />

--- a/app/components/pages/components/homepage-client.js
+++ b/app/components/pages/components/homepage-client.js
@@ -1,6 +1,14 @@
 "use client";
 import { useRef } from "react";
-import { Box, Text, Flex, HStack, Heading, SimpleGrid } from "@chakra-ui/react";
+import {
+  Box,
+  Text,
+  Flex,
+  HStack,
+  Heading,
+  SimpleGrid,
+  Container,
+} from "@chakra-ui/react";
 import Hero from "../../Hero";
 import ProjectCard from "../../ProjectCard";
 import SecondaryButton from "../../Buttons/SecondaryButton";
@@ -40,14 +48,23 @@ export const Home = ({ data, projects }) => {
           Featured Projects
         </Text>
 
-        <SimpleGrid columns={{ sm: 1, md: 2, xl: 3 }} spacing="1rem" my="1rem">
-          {[25, 55, 70, 91, 154, 200].map((index) => (
-            <ProjectCard
-              key={projects[index].repoLink}
-              project={projects[index]}
-            />
-          ))}
-        </SimpleGrid>
+        <Container overflowX="hidden" maxW="container.xl" centerContent top>
+          <SimpleGrid
+            columns={{ sm: 1, md: 2, xl: 3 }}
+            spacing="1rem"
+            spacingX={{ sm: "0rem", md: "2rem" }}
+            spacingY={{ base: "2rem", md: "2rem" }}
+            my="1rem"
+            maxWidth="1385px"
+          >
+            {[25, 55, 70, 91, 154, 200].map((index) => (
+              <ProjectCard
+                key={projects[index].repoLink}
+                project={projects[index]}
+              />
+            ))}
+          </SimpleGrid>
+        </Container>
 
         <SecondaryButton text="See All Projects" link="/projects" />
       </Flex>


### PR DESCRIPTION
## What does this PR do?

This PR fixes Issue:#304

The cards in the grid (on the homepage and projects page) are no longer overflowing the grid container's boundary. The cards are also distributed better now. 3/2/1 columns on different screen sizes.

<img width="1282" alt="image" src="https://github.com/acekyd/made-in-nigeria/assets/18689106/08f45c68-3327-44b7-bef3-2b843aa6ce6d">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Testing should be done on responsiveness.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Ran `npm run build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR

https://github.com/acekyd/made-in-nigeria/assets/18689106/0103cd36-da10-4646-889b-806ef02422b9