### PR TITLE
Add chore PRs

### DIFF
--- a/.github/workflows/enrich-projects.yml
+++ b/.github/workflows/enrich-projects.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   enrich:
@@ -15,8 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.BOT_PAT }}
 
       - uses: actions/setup-node@v4
         with:
@@ -27,19 +26,21 @@ jobs:
 
       - name: Run enrichment
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/enrich-projects.mjs
 
-      - name: Check for changes
-        id: diff
-        run: |
-          git diff --quiet data/projects.enriched.json && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
+      - name: Open PR with enriched data
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update enriched project data"
+          branch: chore/enrich-projects
+          delete-branch: true
+          title: "chore: update enriched project data"
+          body: |
+            Weekly automated update of `data/projects.enriched.json`.
 
-      - name: Commit and push enriched data
-        if: steps.diff.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/projects.enriched.json
-          git commit -m "chore: update enriched project data [skip ci]"
-          git push
+            Pulls latest star counts, last-push dates, languages, and computed
+            statuses from the GitHub API for all tracked projects.
+
+            This PR was opened automatically and is safe to merge.
+          labels: automated

--- a/.github/workflows/enrich-projects.yml
+++ b/.github/workflows/enrich-projects.yml
@@ -30,11 +30,13 @@ jobs:
         run: node scripts/enrich-projects.mjs
 
       - name: Open PR with enriched data
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: "chore: update enriched project data"
           branch: chore/enrich-projects
+          base: main
           delete-branch: true
+          add-paths: data/projects.enriched.json
           title: "chore: update enriched project data"
           body: |
             Weekly automated update of `data/projects.enriched.json`.

--- a/.github/workflows/enrich-projects.yml
+++ b/.github/workflows/enrich-projects.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 2 * * 1"
   workflow_dispatch: {}
 
+concurrency:
+  group: enrich-projects
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -15,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 

--- a/.github/workflows/enrich-projects.yml
+++ b/.github/workflows/enrich-projects.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   enrich:
@@ -16,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_PAT }}
 
       - uses: actions/setup-node@v4
         with:
@@ -26,7 +27,7 @@ jobs:
 
       - name: Run enrichment
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
         run: node scripts/enrich-projects.mjs
 
       - name: Check for changes
@@ -34,7 +35,7 @@ jobs:
         run: |
           git diff --quiet data/projects.enriched.json && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
 
-      - name: Commit enriched data
+      - name: Commit and push enriched data
         if: steps.diff.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -8,6 +8,10 @@ on:
       - "data/projects.json"
   workflow_dispatch: {}
 
+concurrency:
+  group: generate-readme
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -17,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_PAT }}
 
       - uses: actions/setup-node@v4
         with:
@@ -33,7 +35,7 @@ jobs:
         run: |
           git diff --quiet README.MD && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
 
-      - name: Commit README
+      - name: Commit and push README
         if: steps.diff.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -30,11 +30,13 @@ jobs:
         run: node scripts/generate-readme.mjs
 
       - name: Open PR with updated README
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: "chore: regenerate README from projects.json"
           branch: chore/regenerate-readme
+          base: main
           delete-branch: true
+          add-paths: README.MD
           title: "chore: regenerate README from projects.json"
           body: |
             Automated README update triggered by changes to `data/projects.json`.

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate:
@@ -17,8 +18,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.BOT_PAT }}
 
       - uses: actions/setup-node@v4
         with:
@@ -30,16 +29,15 @@ jobs:
       - name: Regenerate README
         run: node scripts/generate-readme.mjs
 
-      - name: Check for changes
-        id: diff
-        run: |
-          git diff --quiet README.MD && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
+      - name: Open PR with updated README
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: regenerate README from projects.json"
+          branch: chore/regenerate-readme
+          delete-branch: true
+          title: "chore: regenerate README from projects.json"
+          body: |
+            Automated README update triggered by changes to `data/projects.json`.
 
-      - name: Commit and push README
-        if: steps.diff.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.MD
-          git commit -m "chore: regenerate README from projects.json [skip ci]"
-          git push
+            This PR was opened automatically and is safe to merge.
+          labels: automated

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -5,14 +5,21 @@ on:
     paths:
       - "data/projects.json"
 
+concurrency:
+  group: validate-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 

--- a/scripts/enrich-projects.mjs
+++ b/scripts/enrich-projects.mjs
@@ -7,7 +7,7 @@
  * Usage: node scripts/enrich-projects.mjs
  */
 
-import { root, ENRICHED_PATH, readProjects, writeJSON } from "./utils.mjs";
+import { ENRICHED_PATH, readProjects, writeJSON } from "./utils.mjs";
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const TODAY = new Date().toISOString().split("T")[0];
@@ -34,7 +34,7 @@ async function getRateLimitRetryMs(res) {
 
   const remaining = res.headers.get("x-ratelimit-remaining");
   const reset = res.headers.get("x-ratelimit-reset");
-  if (remaining === "0" || reset) {
+  if (remaining === "0") {
     const resetSeconds = parseInt(reset, 10);
     if (!Number.isNaN(resetSeconds)) {
       return Math.max(0, resetSeconds * 1000 - Date.now()) + 1000;


### PR DESCRIPTION
I forgot about the gate to avoid direct commits to main, so enabled quick automated chore PRs from the workflows. Safe to observe and get back to later on based on performance. 