### PR TITLE
feat: add Tablesmit to projects

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -2688,6 +2688,17 @@
     "manualStatus": "inactive"
   },
   {
+    "name": "Tablesmit",
+    "repoUrl": "https://github.com/Olayiwola72/tablesmit",
+    "description": "A minimalist, open source table builder for analytical writing. Build clean structured tables with full control over headers, column types, and formatting. Supports drag-to-resize, merge cells, smart clipboard paste from Excel, and export to PDF, Excel, CSV, and PNG. No signup required.",
+    "authors": [
+      {
+        "name": "@OlayiwolaAkinn1",
+        "link": "https://x.com/OlayiwolaAkinn1"
+      }
+    ]
+  },
+  {
     "name": "TenseiJS",
     "repoUrl": "https://github.com/tenseijs/tensei",
     "description": "Content management and distribution with a touch of elegance.",


### PR DESCRIPTION
## Adding Tablesmit to Made in Nigeria OSS

**Project:** Tablesmit
**Repo:** https://github.com/Olayiwola72/tablesmit
**Live URL:** https://tablesmit.com

**What it does:**
Tablesmit is a minimalist, open source table builder for analytical writing.
It lets writers, analysts, and researchers build clean structured tables with
full control over headers, column formatting, and export — all in the browser,
no signup required.

**Why it qualifies:**
- Built and maintained by a Nigerian developer
- MIT licensed, fully open source
- Solves a general problem for a global audience (not Nigeria-specific)
- ★ 20 GitHub stars at time of submission

**Checklist:**
- [x] Entry added to data/projects.json
- [x] npm run build passes with no errors
- [x] No console.log statements
- [x] Social link provided (Twitter/X — outside GitHub)